### PR TITLE
fix docker go build error due to low golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine3.15 AS builder
+FROM golang:1.19.1-alpine3.15 AS builder
 
 LABEL stage=gobuilder
 


### PR DESCRIPTION
Upgrade go version from 1.17 to 1.19