### PR TITLE
fix: properly handle errors in QR code login flow

### DIFF
--- a/cmd/app/login.go
+++ b/cmd/app/login.go
@@ -19,8 +19,11 @@ func LoginByCookie(cookie string) (err error) {
 	}
 	// save config
 	u.CookieStr = cookie
-	config.Instance.SetUser(&u)
-	config.Instance.Save()
+	_, err = config.Instance.SetUser(&u)
+	if err != nil {
+		return
+	}
+	err = config.Instance.Save()
 	return
 }
 
@@ -51,6 +54,9 @@ func LoginByQr() error {
 			}
 			if check.Data.Status == 1 {
 				err = LoginByCookie(cookie)
+				if err != nil {
+					return err
+				}
 				fmt.Println("扫码成功")
 				return nil
 			} else if check.Data.Status == 2 {

--- a/services/service.go
+++ b/services/service.go
@@ -221,7 +221,8 @@ func ParseCookies(cookie string, v interface{}) (err error) {
 	list := strings.Split(cookie, ";")
 	cookieM := make(map[string]string, len(list))
 	for _, item := range list {
-		parts := strings.Split(item, "=")
+		// Use SplitN to handle values containing '=' (e.g., base64 encoded tokens)
+		parts := strings.SplitN(item, "=", 2)
 		if len(parts) > 1 {
 			if parts[1] != "" {
 				cookieM[strings.TrimSpace(parts[0])] = parts[1]


### PR DESCRIPTION
## Problem

QR code login (`dedao-dl login -q`) appears to succeed but the session is not actually persisted to `config.json`. After the login command completes, subsequent commands fail with "未登陆" (not logged in).

### Observed Behavior
1. Run `dedao-dl login -q`
2. Scan QR code successfully
3. Command shows "扫码成功" and displays user info
4. Run `dedao-dl course` or any other command
5. **Fails**: Session not found, prompts to login again

### Expected Behavior
After successful QR login, the session should persist to `config.json` just like cookie-based login (`dedao-dl login -c "GAT=..."`).

## Root Cause

Three bugs found:

### Bug 1: `LoginByCookie()` ignores errors (cmd/app/login.go)
```go
// Before (broken)
config.Instance.SetUser(&u)   // Error ignored!
config.Instance.Save()        // Error ignored!
```

The `err` variable was set by `ParseCookies()` but never updated, so errors from `SetUser()` or `Save()` were silently swallowed.

### Bug 2: `LoginByQr()` returns nil instead of error (cmd/app/login.go)
```go
// Before (broken)
err = LoginByCookie(cookie)
fmt.Println("扫码成功")
return nil  // Should return err!
```

Even if `LoginByCookie()` returned an error, the function returned `nil`, masking the failure.

### Bug 3: `ParseCookies()` truncates values containing `=` (services/service.go)
```go
// Before (broken) - truncates at first '='
parts := strings.Split(item, "=")

// After (fixed) - preserves full value
parts := strings.SplitN(item, "=", 2)
```

Cookie values containing `=` (like base64 encoded tokens) would be truncated. For example, `GAT=abc=def=ghi` would become `GAT=abc`, losing the rest.

## Fix

1. **Properly capture and return errors from `SetUser()` and `Save()`**
2. **Return error from `LoginByQr()` if `LoginByCookie()` fails**
3. **Use `SplitN` to preserve full cookie values**

## Testing

Built and tested locally. With these fixes:
- If login succeeds, session is properly saved to `config.json`
- If there's an error during save, the user sees the error message instead of a false success
- Cookie values are correctly parsed regardless of content

## Impact

Minimal, targeted fix that only changes error handling and cookie parsing logic. No changes to the login flow itself or any other functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login error handling so authentication failures are now detected and reported reliably.
  * Fixed cookie parsing to correctly handle values containing '=' (e.g., encoded tokens), reducing login/session issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->