### PR TITLE
ci: 升级 GitHub Actions 并强制 Node.js 24 环境

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
 
@@ -45,28 +48,29 @@ jobs:
             ext: .exe
             archive: zip
             upx: true
-          - goos: windows
-            goarch: arm64
-            ext: .exe
-            archive: zip
-            upx: true
     env:
       BINARY_NAME: dedao-dl
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Install UPX
         if: matrix.upx
-        uses: crazy-max/ghaction-upx@v3
-        with:
-          version: latest
+        run: |
+          set -euo pipefail
+          if command -v upx >/dev/null 2>&1; then
+            upx --version
+            exit 0
+          fi
+          sudo apt-get update
+          sudo apt-get install -y upx-ucl || sudo apt-get install -y upx
+          upx --version
 
       - name: Build binary
         env:
@@ -99,7 +103,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -113,12 +117,12 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
- 添加 FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 环境变量以强制使用 Node.js 24
- 将 actions/checkout 从 v4 升级到 v5
- 将 actions/setup-go 从 v5 升级到 v6
- 将 actions/upload-artifact 从 v4 升级到 v6
- 将 actions/download-artifact 从 v4 升级到 v7
- 移除 Windows ARM64 构建目标以简化矩阵
- 将 UPX 安装从第三方 Action 替换为直接 apt 安装，提高可靠性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions to latest versions for improved compatibility and reliability
  * Refined build configuration matrix with optimized platform targeting
  * Enhanced build automation tooling and environment setup procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->