### PR TITLE
:art: article md link fixed

### DIFF
--- a/cmd/app/download.go
+++ b/cmd/app/download.go
@@ -797,11 +797,11 @@ func ContentsToMarkdown(contents []services.Content) (res string) {
 		switch content.Type {
 		case "audio":
 			title := strings.TrimRight(content.Title, ".mp3")
-			res += getMdHeader(1) + title + "\r\n\r\n"
+			res += utils.MarkdownHeader(1) + title + "\r\n\r\n"
 		case "header":
 			content.Text = strings.Trim(content.Text, " ")
 			if len(content.Text) > 0 {
-				res += getMdHeader(content.Level) + content.Text + "\r\n\r\n"
+				res += utils.MarkdownHeader(content.Level) + content.Text + "\r\n\r\n"
 			}
 		case "blockquote":
 			texts := strings.Split(content.Text, "\n")
@@ -824,7 +824,7 @@ func ContentsToMarkdown(contents []services.Content) (res string) {
 			}
 			res += resL
 		case "elite": // 划重点
-			res += getMdHeader(2) + "划重点\r\n\r\n" + content.Text + "\r\n\r\n"
+			res += utils.MarkdownHeader(2) + "划重点\r\n\r\n" + content.Text + "\r\n\r\n"
 
 		case "image":
 			res += "![" + content.URL + "](" + content.URL
@@ -833,7 +833,7 @@ func ContentsToMarkdown(contents []services.Content) (res string) {
 			}
 			res += ")" + "\r\n\r\n"
 		case "label-group":
-			res += getMdHeader(2) + "`" + content.Text + "`" + "\r\n\r\n"
+			res += utils.MarkdownHeader(2) + "`" + content.Text + "`" + "\r\n\r\n"
 		}
 	}
 
@@ -853,14 +853,17 @@ func paragraphToMarkDown(content interface{}) (res string, err error) {
 	}
 	for _, item := range cont {
 		subContent := strings.Trim(item.Text.Content, " ")
+		link := utils.NormalizeMarkdownLink(item.Text.Link)
 		switch item.Type {
 		case "text":
 			if item.Text.Bold {
 				res += " **" + subContent + "** "
 			} else if item.Text.Highlight {
 				res += " *" + subContent + "* "
+			} else if link != "" {
+				res += "[" + subContent + "](" + link + ") "
 			} else {
-				res += subContent
+				res += subContent + " "
 			}
 		}
 	}
@@ -884,12 +887,15 @@ func listToMarkdown(content interface{}) (res string, err error) {
 	for _, item := range cont {
 		for _, item := range item {
 			subContent := strings.Trim(item.Text.Content, " ")
+			link := utils.NormalizeMarkdownLink(item.Text.Link)
 			switch item.Type {
 			case "text":
 				if item.Text.Bold {
 					res += "* **" + subContent + "** "
 				} else if item.Text.Highlight {
 					res += "* *" + subContent + "* "
+				} else if link != "" {
+					res += "* [" + subContent + "](" + link + ") "
 				} else {
 					res += "* " + subContent
 				}
@@ -901,7 +907,7 @@ func listToMarkdown(content interface{}) (res string, err error) {
 }
 
 func articleCommentsToMarkdown(contents []services.ArticleComment) (res string) {
-	res = getMdHeader(2) + "热门留言\r\n\r\n"
+	res = utils.MarkdownHeader(2) + "热门留言\r\n\r\n"
 	for _, content := range contents {
 		res += content.NotesOwner.Name + "：" + content.Note + "\r\n\r\n"
 		if content.CommentReply != "" {
@@ -910,21 +916,6 @@ func articleCommentsToMarkdown(contents []services.ArticleComment) (res string) 
 	}
 	res += "---\r\n"
 	return
-}
-
-func getMdHeader(level int) string {
-	heads := map[int]string{
-		1: "# ",
-		2: "## ",
-		3: "### ",
-		4: "#### ",
-		5: "##### ",
-		6: "###### ",
-	}
-	if s, ok := heads[level]; ok {
-		return s
-	}
-	return ""
 }
 
 func courseArticleDetailByEnid(articleEnid string) (detail *services.ArticleDetail, err error) {

--- a/services/article.go
+++ b/services/article.go
@@ -34,6 +34,7 @@ type Contents []struct {
 		Bold      bool   `json:"bold"`
 		Content   string `json:"content"`
 		Highlight bool   `json:"highlight"`
+		Link      string `json:"link"`
 	} `json:"text"`
 	Type string `json:"type"`
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -155,6 +155,48 @@ func ResolveURL(u *url.URL, p string) string {
 	return baseURL + path.Join("/", p)
 }
 
+func NormalizeMarkdownLink(rawLink string) string {
+	rawLink = strings.TrimSpace(rawLink)
+	if rawLink == "" {
+		return ""
+	}
+	if strings.HasPrefix(rawLink, "http://") || strings.HasPrefix(rawLink, "https://") {
+		return rawLink
+	}
+	parsedURL, err := url.Parse(rawLink)
+	if err != nil {
+		return rawLink
+	}
+	decodedLink := strings.TrimSpace(parsedURL.Query().Get("url"))
+	if decodedLink == "" {
+		return rawLink
+	}
+	decodedLink, err = url.QueryUnescape(decodedLink)
+	if err != nil {
+		return rawLink
+	}
+	decodedLink = strings.TrimSpace(decodedLink)
+	if decodedLink == "" {
+		return rawLink
+	}
+	return decodedLink
+}
+
+func MarkdownHeader(level int) string {
+	headers := map[int]string{
+		1: "# ",
+		2: "## ",
+		3: "### ",
+		4: "#### ",
+		5: "##### ",
+		6: "###### ",
+	}
+	if value, ok := headers[level]; ok {
+		return value
+	}
+	return ""
+}
+
 // DrawProgressBar Draw ProgressBar
 func DrawProgressBar(prefix string, proportion float32, width int, suffix ...string) {
 	pos := int(proportion * float32(width))

--- a/web/api/article.go
+++ b/web/api/article.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/yann0917/dedao-dl/config"
 	"github.com/yann0917/dedao-dl/services"
+	"github.com/yann0917/dedao-dl/utils"
 )
 
 const articleAppID = "1632426125495894021"
@@ -69,11 +70,11 @@ func contentsToMarkdown(contents []services.Content) (res string) {
 		switch content.Type {
 		case "audio":
 			title := strings.TrimRight(content.Title, ".mp3")
-			res += getMDHeader(1) + title + "\r\n\r\n"
+			res += utils.MarkdownHeader(1) + title + "\r\n\r\n"
 		case "header":
 			content.Text = strings.Trim(content.Text, " ")
 			if len(content.Text) > 0 {
-				res += getMDHeader(content.Level) + content.Text + "\r\n\r\n"
+				res += utils.MarkdownHeader(content.Level) + content.Text + "\r\n\r\n"
 			}
 		case "blockquote":
 			texts := strings.Split(content.Text, "\n")
@@ -96,7 +97,7 @@ func contentsToMarkdown(contents []services.Content) (res string) {
 			}
 			res += resL
 		case "elite":
-			res += getMDHeader(2) + "划重点\r\n\r\n" + content.Text + "\r\n\r\n"
+			res += utils.MarkdownHeader(2) + "划重点\r\n\r\n" + content.Text + "\r\n\r\n"
 		case "image":
 			res += "![" + content.URL + "](" + content.URL
 			if content.Legend != "" {
@@ -104,7 +105,7 @@ func contentsToMarkdown(contents []services.Content) (res string) {
 			}
 			res += ")" + "\r\n\r\n"
 		case "label-group":
-			res += getMDHeader(2) + "`" + content.Text + "`" + "\r\n\r\n"
+			res += utils.MarkdownHeader(2) + "`" + content.Text + "`" + "\r\n\r\n"
 		}
 	}
 
@@ -125,12 +126,15 @@ func paragraphToMarkdown(content interface{}) (res string, err error) {
 
 	for _, item := range cont {
 		subContent := strings.Trim(item.Text.Content, " ")
+		link := utils.NormalizeMarkdownLink(item.Text.Link)
 		switch item.Type {
 		case "text":
 			if item.Text.Bold {
 				res += " **" + subContent + "** "
 			} else if item.Text.Highlight {
 				res += " *" + subContent + "* "
+			} else if link != "" {
+				res += "[" + subContent + "](" + link + ") "
 			} else {
 				res += subContent
 			}
@@ -157,12 +161,15 @@ func listToMarkdown(content interface{}) (res string, err error) {
 	for _, group := range cont {
 		for _, item := range group {
 			subContent := strings.Trim(item.Text.Content, " ")
+			link := utils.NormalizeMarkdownLink(item.Text.Link)
 			switch item.Type {
 			case "text":
 				if item.Text.Bold {
 					res += "* **" + subContent + "** "
 				} else if item.Text.Highlight {
 					res += "* *" + subContent + "* "
+				} else if link != "" {
+					res += "* [" + subContent + "](" + link + ") "
 				} else {
 					res += "* " + subContent
 				}
@@ -172,21 +179,4 @@ func listToMarkdown(content interface{}) (res string, err error) {
 	}
 
 	return
-}
-
-func getMDHeader(level int) string {
-	headers := map[int]string{
-		1: "# ",
-		2: "## ",
-		3: "### ",
-		4: "#### ",
-		5: "##### ",
-		6: "###### ",
-	}
-
-	if value, ok := headers[level]; ok {
-		return value
-	}
-
-	return ""
 }


### PR DESCRIPTION
markdown 格式文章 新增跳转链接样式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown exports now preserve article links as clickable Markdown links.
  * Links embedded in article content are normalized for cleaner, more reliable output.

* **Bug Fixes**
  * Improved consistency of headings across exported Markdown sections, including audio, highlighted, and grouped content.
  * Updated comment section headings to follow the same formatting as the rest of the export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->