### PR TITLE
fix: Windows PDF generation fails on cover page

### DIFF
--- a/utils/genPdf.go
+++ b/utils/genPdf.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/SebastiaanKlippert/go-wkhtmltopdf"
 )
@@ -29,13 +30,16 @@ func (p *PdfOption) GenPdf(buf *bytes.Buffer) (err error) {
 
 	if p.CoverPath != "" {
 		pdfg.Cover.EnableLocalFileAccess.Set(true)
-		dir, err := CurrentDir()
+		dir, err := os.Getwd()
 		if err != nil {
 			pdfg.Cover.EnableLocalFileAccess.Set(false)
 		}
 		dir = filepath.Join(dir, p.CoverPath)
 		if runtime.GOOS == "windows" {
-			pdfg.Cover.Input = dir
+			// Windows: 反斜杠路径会被 wkhtmltopdf 当作 URL 协议(c:)解析失败，
+			// 统一转为正斜杠 file:// URL
+			dir = strings.ReplaceAll(dir, "\\", "/")
+			pdfg.Cover.Input = "file:///" + dir
 		} else {
 			pdfg.Cover.Input = "file://" + dir
 		}


### PR DESCRIPTION
## Problem

On Windows, `dedao-dl dle <id> -t 2` (PDF download) always fails.

Two root causes in `utils/genPdf.go` `GenPdf()`:

1. **Wrong base directory**: cover path is joined onto `CurrentDir()`, which resolves to the *executable's* directory (`os.Args[0]`). But `Svg2Pdf` writes `cover.html` relative to the *current working directory*. On Windows (where the binary usually lives in a different folder, e.g. GitHub releases binary in a tools dir), wkhtmltopdf can't find the cover file.

2. **Backslash treated as URL protocol**: the Windows branch passes the raw Windows path (`c:\Users\...\cover.html`) to wkhtmltopdf's `--cover`, which parses `c:` as a URL protocol → `ProtocolUnknownError: Protocol "c" is unknown` → exit code 1, PDF never generated.

## Fix

- Use `os.Getwd()` as the base for the cover path, matching where the chapter/cover files are actually written.
- On Windows, normalize backslashes to forward slashes and pass the cover as a `file:///` URL.

## Test

Verified on Windows 11 with wkhtmltopdf 0.12.6 (winget package): `dle` PDF generation now completes successfully (cover, TOC page numbers, 300 DPI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF cover image loading across operating systems.
  * Fixed Windows path handling to ensure cover images display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->