### PR TITLE
Revert "fix: Windows PDF generation fails on cover page"

### DIFF
--- a/utils/genPdf.go
+++ b/utils/genPdf.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/SebastiaanKlippert/go-wkhtmltopdf"
 )
@@ -30,16 +29,13 @@ func (p *PdfOption) GenPdf(buf *bytes.Buffer) (err error) {
 
 	if p.CoverPath != "" {
 		pdfg.Cover.EnableLocalFileAccess.Set(true)
-		dir, err := os.Getwd()
+		dir, err := CurrentDir()
 		if err != nil {
 			pdfg.Cover.EnableLocalFileAccess.Set(false)
 		}
 		dir = filepath.Join(dir, p.CoverPath)
 		if runtime.GOOS == "windows" {
-			// Windows: 反斜杠路径会被 wkhtmltopdf 当作 URL 协议(c:)解析失败，
-			// 统一转为正斜杠 file:// URL
-			dir = strings.ReplaceAll(dir, "\\", "/")
-			pdfg.Cover.Input = "file:///" + dir
+			pdfg.Cover.Input = dir
 		} else {
 			pdfg.Cover.Input = "file://" + dir
 		}


### PR DESCRIPTION
Reverts yann0917/dedao-dl#348 改完mac 下下载pdf 不对了，AI 修复的没验证吧

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF cover image path handling across operating systems.
  * Fixed Windows cover paths so they load correctly without unnecessary URL conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->